### PR TITLE
Fix notes without 'updated' field having their update time set to null

### DIFF
--- a/lib/sntools.js
+++ b/lib/sntools.js
@@ -116,7 +116,7 @@ class SNTools {
 
       var note = {
         created_at: moment(created).toDate(),
-        updated_at: updated ? moment(updated).toDate() : null,
+        updated_at: updated ? moment(updated).toDate() : moment(created).toDate(),
         uuid: this.generateUUID(),
         content_type: "Note",
         content: {


### PR DESCRIPTION
Notes without 'updated' fields are currently set to null, and when read in
standard notes this is converted to the unix epoch start. This will set
'updated' to the 'created' field when 'updated' is null.

For example: 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export2.dtd">
<en-export export-date="20180819T181512Z" application="Evernote" version="6.x">
<note><title>title</title><content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">

<en-note><div>note</div></en-note>]]></content><created>20180819T181427Z</created><note-attributes><author>me</author><source>source</source><source-application>evernote</source-application></note-attributes></note></en-export>
```

Is currently converted to: 
```json
{
  "items": [
    {
      "created_at": "2018-08-19T18:14:27.000Z",
      "updated_at": null,
      "uuid": "4510b77c-51ab-4ee7-9510-3955a07b2e81",
      "content_type": "Note",
      "content": {
        "title": "title",
        "text": "note",
        "references": []
      }
    },
    {
      "uuid": "eac6cae6-d814-4aeb-861f-fe53b87f8376",
      "content_type": "Tag",
      "content": {
        "title": "evernote",
        "references": [
          {
            "content_type": "Note",
            "uuid": "4510b77c-51ab-4ee7-9510-3955a07b2e81"
          }
        ]
      }
    }
  ]
}

```

Which in standard notes makes the highlighted date appear as 1970-01-01. This just assumes the updated date to be the created date, if it's null.

😄 